### PR TITLE
[MLP-196] Create front end initial structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _ReSharper*/
 [Tt]est[Rr]esult*
 packages/
 .vs/config/applicationhost.config
+webapp/node_modules/**/*

--- a/P202.Training.WCF/Global.asax.cs
+++ b/P202.Training.WCF/Global.asax.cs
@@ -7,6 +7,7 @@ using P202.Training.Domain;
 using P202.Training.WCF.RequestsAndResponses;
 using System;
 using System.Reflection;
+using System.Web;
 
 namespace P202.Training.WCF
 {
@@ -36,6 +37,19 @@ namespace P202.Training.WCF
 
             new ServiceLayerConfiguration(Assembly.GetExecutingAssembly(), typeof(EchoRequest).Assembly, agathaContainer).Initialize();
 
+        }
+
+        protected void Application_BeginRequest(object sender, EventArgs e)
+        {
+            HttpContext.Current.Response.AddHeader("Access-Control-Allow-Origin", "*");
+            if (HttpContext.Current.Request.HttpMethod == "OPTIONS")
+            {
+                HttpContext.Current.Response.AddHeader("Cache-Control", "no-cache");
+                HttpContext.Current.Response.AddHeader("Access-Control-Allow-Methods", "GET, POST");
+                HttpContext.Current.Response.AddHeader("Access-Control-Allow-Headers", "Content-Type, Accept, Authorization");
+                HttpContext.Current.Response.AddHeader("Access-Control-Max-Age", "1728000");
+                HttpContext.Current.Response.End();
+            }
         }
     }
 }

--- a/P202.Training.WCF/Web.config
+++ b/P202.Training.WCF/Web.config
@@ -25,12 +25,12 @@
         <endpoint address="" contract="Agatha.Common.WCF.IWcfRequestProcessor" binding="basicHttpBinding" bindingConfiguration="RequestProcessorBinding" />
         <endpoint address="xml" contract="Agatha.Common.WCF.IWcfRestXmlRequestProcessor" binding="webHttpBinding" behaviorConfiguration="restBehavior" />
         <endpoint address="json" contract="Agatha.Common.WCF.IWcfRestJsonRequestProcessor" binding="webHttpBinding" behaviorConfiguration="restBehavior" />
-        <endpoint address="jsonp" contract="Agatha.Common.WCF.IWcfRestJsonRequestProcessor" binding="webHttpBinding" bindingConfiguration="webBindingWithJsonP" behaviorConfiguration="restBehavior" />
+        <endpoint address="jsonp" contract="Agatha.Common.WCF.IWcfRestJsonRequestProcessor" binding="webHttpBinding" bindingConfiguration="crossDomain" behaviorConfiguration="restBehavior"/>
       </service>
     </services>
     <bindings>
       <webHttpBinding>
-        <binding name="webBindingWithJsonP" crossDomainScriptAccessEnabled="true" />
+        <binding name="crossDomain" crossDomainScriptAccessEnabled="true"/>
       </webHttpBinding>
       <basicHttpBinding>
         <binding name="RequestProcessorBinding" maxReceivedMessageSize="2147483647" receiveTimeout="00:30:00" sendTimeout="00:30:00">

--- a/webapp/app/main.js
+++ b/webapp/app/main.js
@@ -1,0 +1,32 @@
+var ko = require('knockout');
+var app = require('durandal/app');
+var system = require('durandal/system');
+
+// Durandal core overrides - Required for Webpack
+require('overrides/system');
+require('overrides/composition');
+require('overrides/views');
+
+// Webpack sets this __DEV__ variable. See `webpack.config.js` file
+if(__DEV__) {
+	system.debug(true);
+
+	window.ko = ko;
+	window.app = app;
+	window.router = router;
+}
+
+// Install the router
+var router = require('plugins/router');
+router.install({});
+
+
+// Start the appliction
+app.start().then(function () {
+	// Set the title
+	app.title = 'P202 training';
+
+	// Show the app by setting the root view model for our application with a transition.
+	var shell = require('./shell');
+	return app.setRoot(shell);
+});

--- a/webapp/app/overrides/composition.js
+++ b/webapp/app/overrides/composition.js
@@ -1,0 +1,15 @@
+var system = require('durandal/system');
+var composition = require('durandal/composition');
+
+var compose = composition.compose;
+composition.compose = function(element, settings) {
+	// If the `model` isn't a `moduleId` string, assume it's the module
+	// itself and resolve it using the `system` module
+	if('string' !== typeof settings.model) {
+		settings.model = system.resolveObject(settings.model);
+	}
+
+	// super()
+	return compose.apply(this, arguments);
+};
+

--- a/webapp/app/overrides/system.js
+++ b/webapp/app/overrides/system.js
@@ -1,0 +1,33 @@
+var system = require('durandal/system');
+
+var acquire = system.acquire;
+system.acquire = function(moduleIdOrModule) {
+	var isModule = typeof moduleIdOrModule !== 'string' && !(moduleIdOrModule instanceof Array);
+	if(isModule) {
+		return system.defer(function(dfd) {
+			// If the moduleId is a function...
+			if(moduleIdOrModule instanceof Function) {
+				// Execute the function, passing a callback that should be 
+				// called when the (possibly) async operation is finished
+				var result = moduleIdOrModule(function(err, module) {
+					if(err) { dfd.reject(err); }
+					dfd.resolve(module);
+				});
+
+				// Also allow shorthand `return` from the funcction, which 
+				// resolves the Promise with whatever was immediately returned
+				if(result !== undefined) {
+					dfd.resolve(result);
+				}
+			}
+
+			// If the moduleId is actually an object, simply resolve with it
+			else {
+				dfd.resolve(moduleIdOrModule);
+			}
+		});
+	}
+
+	// super()
+	return acquire.apply(this, arguments);
+};

--- a/webapp/app/overrides/views.js
+++ b/webapp/app/overrides/views.js
@@ -1,0 +1,19 @@
+var $ = require('jquery');
+var system = require('durandal/system');
+var viewLocator = require('durandal/viewLocator');
+
+// Allow using `function` or bare HTML string as a view
+var locateView = viewLocator.locateView;
+viewLocator.locateView = function(viewOrUrlOrId, area) {
+	var viewId;
+
+	// HTML here will be passed into `processMarkup`
+	if('string' === typeof viewOrUrlOrId && $.trim(viewOrUrlOrId).charAt(0) === '<') {
+		return system.defer(function(dfd) {
+			dfd.resolve(viewOrUrlOrId);
+		});
+	}
+
+	// super()
+	return locateView.apply(this, arguments);
+};

--- a/webapp/app/routes.js
+++ b/webapp/app/routes.js
@@ -1,0 +1,24 @@
+var system = require('durandal/system');
+
+module.exports = [
+	// Here we define our routes as usual, but with one important distinction.
+	// Our `moduleId` is no longer a string that points to the module, but rather 
+	// the module itself, as an inline, static dependency. This will bundle the
+	// modules into your main app, but still work as expected in Durandal!
+	{
+		route: '', 
+		title: 'Home',
+		moduleId: function() {
+			return require('viewModels/home/home');
+		},
+		nav: true
+	},
+	{
+		route: 'echo', 
+		title: 'Echo',
+		moduleId: function() {
+			return require('viewModels/echo/echo');
+		},
+		nav: true
+	}
+];

--- a/webapp/app/services/echoService.js
+++ b/webapp/app/services/echoService.js
@@ -1,0 +1,17 @@
+define('services/echoService', [], function () {
+
+  function echo(value) {
+    // TODO: refactor common headers and base url
+    return $.ajax({
+      type: 'POST',
+      contentType: 'application/json',
+      url:'http://localhost:10160/Service.svc/jsonp/post',
+      data: '{"requests":[{"__type":"EchoRequest:#P202.Training.WCF.RequestsAndResponses","Value":' + value + '}]}'
+    });
+  }
+
+  return {
+    echo: echo
+  };
+
+});

--- a/webapp/app/shell.html
+++ b/webapp/app/shell.html
@@ -1,0 +1,24 @@
+<main id="shell">
+	<div class="navbar navbar-default">
+		<div class="container-fluid">
+			<div class="navbar-header">
+				<a class="navbar-brand" data-bind="attr: { href: router.navigationModel()[0].hash }">
+					<i class="icon-home"></i>
+					<span>P202 training</span>
+				</a>
+			</div>
+
+			<ul class="nav navbar-nav" data-bind="foreach: router.navigationModel">
+				<li data-bind="css: { active: isActive }">
+					<a data-bind="attr: { href: hash }, html: title"></a>
+				</li>
+			</ul>
+
+			<div class="loader navbar-right" data-bind="css: { active: router.isNavigating }">
+				<i class="icon-spinner icon-2x icon-spin"></i>
+			</div>
+		</div>
+	</div>
+
+	<div id="page" class="container" data-bind="router: {}"></div>
+</main>

--- a/webapp/app/shell.js
+++ b/webapp/app/shell.js
@@ -1,0 +1,17 @@
+var router = require('plugins/router');
+var ViewModel = require('viewModels/class');
+
+var Shell = new ViewModel({
+	view: require('./shell.html')
+});
+
+Shell.router = router.map(
+	require('./routes')
+)
+.buildNavigationModel();
+
+Shell.activate = function() {
+	return router.activate();
+};
+
+module.exports = Shell;

--- a/webapp/app/viewModels/class.js
+++ b/webapp/app/viewModels/class.js
@@ -1,0 +1,17 @@
+var $ = require('jquery');
+
+function ViewModel(options) {
+	options || (options = {});
+	
+	this.options = options;
+	this.view = options.view;
+}
+
+// Override the default `getView` logic that Durandal utilises to
+// fetch the view for each ViewModel instance.
+ViewModel.prototype.getView = function() {
+	var view = $.trim(this.view);
+	return $.parseHTML(view)[0];
+};
+
+module.exports = ViewModel;

--- a/webapp/app/viewModels/echo/echo.html
+++ b/webapp/app/viewModels/echo/echo.html
@@ -1,0 +1,10 @@
+<section id="echo">
+  <div>
+    <input type="text" data-bind="value: value" />
+  </div>
+  <button type="button" data-bind="click: sendEcho">Send</button>
+  <div>
+    Response:
+    <span data-bind="text: echoResponse"></span>
+  </div>
+</section>

--- a/webapp/app/viewModels/echo/echo.js
+++ b/webapp/app/viewModels/echo/echo.js
@@ -1,0 +1,21 @@
+require('services/echoService');
+
+define('Echo', ['services/echoService'], function (echoService) {
+  var vm = {
+    getView: function () {
+      var view = require('./echo.html');
+      return $.parseHTML(view)[0];
+    },
+    value: ko.observable(0),
+    sendEcho: sendEcho,
+    echoResponse: ko.observable('')
+  };
+
+  function sendEcho() {
+    echoService.echo(this.value()).then(function(response) {
+      vm.echoResponse(response.ProcessJsonRequestsPostResult[0].Value);
+    });
+  }
+
+  return vm;
+});

--- a/webapp/app/viewModels/home/home.html
+++ b/webapp/app/viewModels/home/home.html
@@ -1,0 +1,4 @@
+<section id="home">
+	This is the home module
+
+</section>

--- a/webapp/app/viewModels/home/home.js
+++ b/webapp/app/viewModels/home/home.js
@@ -1,0 +1,7 @@
+var ViewModel = require('viewModels/class');
+
+var Home = new ViewModel({
+	view: require('./home.html')
+});
+
+module.exports = Home;

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>P202 training</title>
+	<link rel="stylesheet" href="node_modules/durandal/css/durandal.css" />
+</head>
+<body>
+	<div id="applicationHost">
+		<!-- This is where the shell will be loaded into by identifying as 'applicationHost'  -->
+	</div>
+	
+	<script src="node_modules/jquery/dist/jquery.min.js"></script>
+	<script src="/dist/app.js"></script>
+</body>
+</html>

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "p202-training.durandal-webpack",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "durandal": "^2.1.0",
+    "jquery": "^2.1.4",
+    "knockout": "^3.3.0"
+  },
+  "devDependencies": {
+    "html-loader": "^0.3.0",
+    "webpack-dev-server": "^1.15.0",
+    "webpack": "^1.10.5"
+  },
+  "scripts": {
+    "start": "webpack-dev-server",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -1,0 +1,76 @@
+var fs = require('fs');
+var url = require('url');
+var path = require('path');
+var webpack = require('webpack');
+
+var DEBUG = !process.argv.production;
+
+var GLOBALS = {
+	'process.env.NODE_ENV': DEBUG ? '"development"' : '"production"',
+	'__DEV__': DEBUG
+};
+
+module.exports = {
+	// Main entry directory and file
+	entry: {
+		app: [
+			// 'webpack/hot/dev-server',
+			path.join(__dirname, 'app', 'main.js')
+		]
+	},
+
+	// Output directories and file
+	output: {
+		path: path.join(__dirname, 'dist'),
+		filename: '[name].js',
+		chunkFilename: '[name].chunk.js',
+		publicPath: '/dist/'
+	},
+
+	// Custom plugins
+	plugins: [
+		new webpack.DefinePlugin(GLOBALS),
+		new webpack.optimize.OccurenceOrderPlugin()
+	]
+	.concat(DEBUG ? [] : [
+		new webpack.optimize.DedupePlugin(),
+		new webpack.optimize.UglifyJsPlugin(),
+		new webpack.optimize.AggressiveMergingPlugin()
+	]),
+
+	module: {
+		loaders: [
+			{ test: /\.html$/, loader: 'html' },
+			{ test: /\.json$/, loader: 'json' }
+		]
+	},
+
+	resolve: {
+		extensions: ['', '.js', '.jsx', '.json'],
+
+		modulesDirectories: [
+			'node_modules',
+			'app'
+		],
+
+		root: path.join(__dirname, 'app'),
+
+		alias: {
+			durandal: 'durandal/js',
+			plugins: 'durandal/js/plugins'
+		}
+	},
+
+	externals: {
+		jquery: 'jQuery'
+	},
+
+	devServer: {
+		contentBase: __dirname,
+		hot: false,
+		inline: true,
+		historyApiFallback: true,
+		stats: { colors: true },
+		progress: true
+	}
+};


### PR DESCRIPTION
# Background
Webapp with knockout and durandal using webpack that is meant to consume the Agatha REST services. As an example I created a View and a ViewModel that consumes the existing `echo` endpoint.

# Changes done
- Enable CORS on WCF project to allow cross domain requests (changes in global.asax)
- Created new webapp folder based on [this repo](https://github.com/Craga89/durandal-webpack)
- Added `Home` and `Echo` views and viewmodels
- Added `EchoService` in charge of making the calls to the API

# Notes
In order to run the webapp you need to have node.js installed. Open the console and go to the webapp folder and run `npm install` for installing all the dependencies and then `npm start` for starting the site

# Pending to be done
Refactor the `EchoService` to extract common logic that will be shared accross other services consuming the API